### PR TITLE
fix: カスタム絵文字申請ページの追加に伴うスキーマ定義ファイルの更新

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -901,6 +901,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_07_071624) do
     t.index ["target_account_id"], name: "index_reports_on_target_account_id"
   end
 
+  create_table "request_custom_emojis", force: :cascade do |t|
+    t.integer "state", default: 0, null: false
+    t.string "shortcode", default: "", null: false
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.integer "image_file_size"
+    t.datetime "image_updated_at", precision: nil
+    t.integer "image_storage_schema_version"
+    t.bigint "account_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "rules", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.datetime "deleted_at", precision: nil
@@ -1317,6 +1330,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_07_071624) do
   add_foreign_key "reports", "accounts", column: "target_account_id", name: "fk_eb37af34f0", on_delete: :cascade
   add_foreign_key "reports", "accounts", name: "fk_4b81f7522c", on_delete: :cascade
   add_foreign_key "reports", "oauth_applications", column: "application_id", on_delete: :nullify
+  add_foreign_key "request_custom_emojis", "accounts", on_update: :cascade, on_delete: :cascade, validate: false
   add_foreign_key "scheduled_statuses", "accounts", on_delete: :cascade
   add_foreign_key "session_activations", "oauth_access_tokens", column: "access_token_id", name: "fk_957e5bda89", on_delete: :cascade
   add_foreign_key "session_activations", "users", name: "fk_e5fda67334", on_delete: :cascade


### PR DESCRIPTION
request_custom_emojiのモデル追加がdb/schema.rbに反映されていなかったため、ローカル環境で`rails db:schema:dump`を実行して更新してみたものです。
放置しても影響はほとんどない修正ですが、お手隙の際にでもレビューして頂けると幸いです。